### PR TITLE
allow users to replace connection urls to connect queues behind proxy

### DIFF
--- a/pulsar/client.go
+++ b/pulsar/client.go
@@ -20,6 +20,7 @@ package pulsar
 import (
 	"github.com/TencentCloud/tdmq-go-client/pulsar/internal/auth"
 	"github.com/TencentCloud/tdmq-go-client/pulsar/internal/authcloud"
+	"net/url"
 	"time"
 )
 
@@ -109,6 +110,8 @@ type ClientOptions struct {
 
 	// Max number of connections to a single broker that will kept in the pool. (Default: 1 connection)
 	MaxConnectionsPerBroker int
+
+	PatchConnURL func(*url.URL)
 }
 
 type Client interface {

--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -113,7 +113,6 @@ func newClient(options ClientOptions) (Client, error) {
 		operationTimeout = defaultOperationTimeout
 	}
 
-
 	if options.NetModel == "" {
 		options.NetModel = NetmodelVpcPulsar
 	}
@@ -125,7 +124,7 @@ func newClient(options ClientOptions) (Client, error) {
 
 	c := &client{
 		options: &options,
-		cnxPool: internal.NewConnectionPoolWithAuthCloud(options.AuthCloud, tlsConfig, authProvider, connectionTimeout,maxConnectionsPerHost),
+		cnxPool: internal.NewConnectionPoolWithAuthCloud(options.AuthCloud, tlsConfig, authProvider, connectionTimeout, maxConnectionsPerHost, options.PatchConnURL),
 	}
 	c.rpcClient = internal.NewRPCClient(url, c.cnxPool, operationTimeout)
 	c.lookupService = internal.NewLookupService(c.rpcClient, url, tlsConfig != nil)


### PR DESCRIPTION


### Motivation

TDMQ currently can only be accessed inside the same VPC. This PR allows users to set-up a proxy in front of it, and access it through proxy.

### Modifications

Add `PatchConnURL func(*url.URL)` to `pulsar.ClientOptions`, which will allow users to modify `physicalAddr` before connecting

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

The changes are backward-compatible, it's an additional and optional field to `ClientOptions`

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (GoDocs)

