### PR TITLE
add String() to MessageID

### DIFF
--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -18,6 +18,7 @@
 package pulsar
 
 import (
+	"fmt"
 	"math/big"
 	"strings"
 	"sync"
@@ -92,6 +93,10 @@ func (id *messageID) Serialize() []byte {
 	}
 	data, _ := proto.Marshal(msgID)
 	return data
+}
+
+func (id *messageID) String() string {
+	return fmt.Sprintf("%d-%d-%d-%d", id.ledgerID, id.entryID, id.batchIdx, id.partitionIdx)
 }
 
 func deserializeMessageID(data []byte) (MessageID, error) {

--- a/pulsar/impl_message_test.go
+++ b/pulsar/impl_message_test.go
@@ -36,6 +36,8 @@ func TestMessageId(t *testing.T) {
 	assert.Equal(t, int32(3), id2.(*messageID).batchIdx)
 	assert.Equal(t, int32(4), id2.(*messageID).partitionIdx)
 
+	assert.Equal(t, id.String(), "1-2-3-4")
+
 	id, err = DeserializeMessageID(nil)
 	assert.Error(t, err)
 	assert.Nil(t, id)

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -111,6 +111,9 @@ type Message interface {
 type MessageID interface {
 	// Serialize the message id into a sequence of bytes that can be stored somewhere else
 	Serialize() []byte
+
+	// String returns string representation of MessageID
+	String() string
 }
 
 // DeserializeMessageID reconstruct a MessageID object from its serialized representation

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -371,6 +371,10 @@ func (id *myMessageID) Serialize() []byte {
 	return id.data
 }
 
+func (id *myMessageID) String() string {
+	return string(id.data)
+}
+
 func TestReaderOnSpecificMessageWithCustomMessageID(t *testing.T) {
 	client, err := NewClient(ClientOptions{
 		URL: lookupURL,


### PR DESCRIPTION

### Motivation

__MessageID__ currently can only be represented as protobuf bytes, which makes no sense to end-user.


### Modifications

add `String() string` to __MessageID__

