### PR TITLE
Add auth token flags for pulsar-perf

### DIFF
--- a/perf/perf-consumer.go
+++ b/perf/perf-consumer.go
@@ -65,9 +65,7 @@ func consume(consumeArgs *ConsumeArgs, stop <-chan struct{}) {
 	b, _ = json.MarshalIndent(consumeArgs, "", "  ")
 	log.Info("Consumer config: ", string(b))
 
-	client, err := pulsar.NewClient(pulsar.ClientOptions{
-		URL: clientArgs.ServiceURL,
-	})
+	client, err := NewClient()
 
 	if err != nil {
 		log.Fatal(err)
@@ -92,6 +90,7 @@ func consume(consumeArgs *ConsumeArgs, stop <-chan struct{}) {
 
 	// Print stats of the consume rate
 	tick := time.NewTicker(10 * time.Second)
+	defer tick.Stop()
 
 	for {
 		select {

--- a/perf/perf-producer.go
+++ b/perf/perf-producer.go
@@ -136,6 +136,7 @@ func produce(produceArgs *ProduceArgs, stop <-chan struct{}) {
 
 	// Print stats of the publish rate and latencies
 	tick := time.NewTicker(10 * time.Second)
+	defer tick.Stop()
 	q := quantile.NewTargeted(0.50, 0.95, 0.99, 0.999, 1.0)
 	messagesPublished := 0
 

--- a/perf/pulsar-perf-go.go
+++ b/perf/pulsar-perf-go.go
@@ -20,6 +20,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -41,7 +42,10 @@ var flagDebug bool
 var PrometheusPort int
 
 type ClientArgs struct {
-	ServiceURL string
+	ServiceURL       string
+	TokenFile        string
+	TLSTrustCertFile string
+	AuthToken       string
 }
 
 var clientArgs ClientArgs
@@ -50,6 +54,25 @@ func NewClient() (pulsar.Client, error) {
 	clientOpts := pulsar.ClientOptions{
 		URL: clientArgs.ServiceURL,
 	}
+
+	if clientArgs.TokenFile != "" {
+		// read JWT from the file
+		tokenBytes, err := ioutil.ReadFile(clientArgs.TokenFile)
+		if err != nil {
+			log.WithError(err).Errorf("failed to read Pulsar JWT from a file %s", clientArgs.TokenFile)
+			os.Exit(1)
+		}
+		clientOpts.Authentication = pulsar.NewAuthenticationToken(string(tokenBytes))
+	}
+
+	if clientArgs.TLSTrustCertFile != "" {
+		clientOpts.TLSTrustCertsFilePath = clientArgs.TLSTrustCertFile
+	}
+
+	if clientArgs.AuthToken != "" {
+		clientOpts.Authentication = pulsar.NewAuthenticationToken(clientArgs.AuthToken)
+	}
+
 	return pulsar.NewClient(clientOpts)
 }
 
@@ -79,6 +102,9 @@ func main() {
 	flags.BoolVar(&flagDebug, "debug", false, "enable debug output")
 	flags.StringVarP(&clientArgs.ServiceURL, "service-url", "u",
 		"pulsar://localhost:6650", "The Pulsar service URL")
+	flags.StringVar(&clientArgs.TokenFile, "token-file", "", "file path to the Pulsar JWT file")
+	flags.StringVar(&clientArgs.AuthToken, "token-string", "", "string to the Pulsar JWT")
+	flags.StringVar(&clientArgs.TLSTrustCertFile, "trust-cert-file", "", "file path to the trusted certificate file")
 
 	rootCmd.AddCommand(newProducerCommand())
 	rootCmd.AddCommand(newConsumerCommand())

--- a/perf/pulsar-perf-go.go
+++ b/perf/pulsar-perf-go.go
@@ -45,7 +45,7 @@ type ClientArgs struct {
 	ServiceURL       string
 	TokenFile        string
 	TLSTrustCertFile string
-	AuthToken       string
+	AuthToken        string
 }
 
 var clientArgs ClientArgs
@@ -98,13 +98,15 @@ func main() {
 
 	flags := rootCmd.PersistentFlags()
 	flags.BoolVar(&FlagProfile, "profile", false, "enable profiling")
-	flags.IntVar(&PrometheusPort, "metrics", 8000, "Port to use to export metrics for Prometheus. Use -1 to disable.")
+	flags.IntVar(&PrometheusPort, "metrics", 8000,
+		"Port to use to export metrics for Prometheus. Use -1 to disable.")
 	flags.BoolVar(&flagDebug, "debug", false, "enable debug output")
 	flags.StringVarP(&clientArgs.ServiceURL, "service-url", "u",
 		"pulsar://localhost:6650", "The Pulsar service URL")
 	flags.StringVar(&clientArgs.TokenFile, "token-file", "", "file path to the Pulsar JWT file")
 	flags.StringVar(&clientArgs.AuthToken, "token-string", "", "string to the Pulsar JWT")
-	flags.StringVar(&clientArgs.TLSTrustCertFile, "trust-cert-file", "", "file path to the trusted certificate file")
+	flags.StringVar(&clientArgs.TLSTrustCertFile, "trust-cert-file", "",
+		"file path to the trusted certificate file")
 
 	rootCmd.AddCommand(newProducerCommand())
 	rootCmd.AddCommand(newConsumerCommand())


### PR DESCRIPTION
Signed-off-by: xiaolongran <rxl@apache.org>

### Motivation

Add token/JWT and trusted certificate support in Pulsar perf go client. So that it can be used in production environment.

### Modifications

Implement pulsar-perf-go command-line arguments for `token-file`, `token-string` and `trusted-cert-file`. These three arguments are optional. There is no change to the default non-TLS and no auth configuration.


#### How to use

```
$ cd perf
$ go build .
$ ./perf
```

Output as follows:

```
      --token-file string        file path to the Pulsar JWT file
      --token-string string      string to the Pulsar JWT
      --trust-cert-file string   file path to the trusted certificate file
```
